### PR TITLE
Client option that toggles ability to recieve open client requests

### DIFF
--- a/src/Client.lua
+++ b/src/Client.lua
@@ -23,8 +23,8 @@ function Client:Create()
   setmetatable(client, Client)
 
   -- Remote messages
-  NotaLoot:RegisterMessage(NotaLoot.MESSAGE.OPEN_CLIENT, function()
-    client:Show()
+  NotaLoot:RegisterMessage(NotaLoot.MESSAGE.OPEN_CLIENT, function(msg, sender)
+    Client:ConfirmShowRequest(sender)
   end)
   NotaLoot:RegisterMessage(NotaLoot.MESSAGE.ADD_ITEM, function(msg, sender, index, encodedItem)
     client:OnAddItem(sender, tonumber(index), NotaLoot.Item:Decode(encodedItem))
@@ -72,6 +72,21 @@ function Client:CreateWindow()
   window:DoLayout()
 
   return window
+end
+
+function Client:ConfirmShowRequest(sender)
+  -- Check whether the client (reciever) wants to recieve show requests from non officers
+  if NotaLoot:GetPref("ShowClientOfficers", true) then
+    if IsInGuild() then
+      local senderRank = select(1, NotaLoot:GetGuildRank(sender))
+      if senderRank and C_GuildInfo.GuildControlGetRankFlags(senderRank)[4] then
+        self:Show()
+      end
+    end
+    return
+  end
+
+  self:Show()
 end
 
 function Client:Show()

--- a/src/Options.lua
+++ b/src/Options.lua
@@ -61,8 +61,25 @@ function NotaLoot:RegisterOptionsTable()
           },
         },
       },
-      devTools = {
+      client = {
         order = 1,
+        name = "Client Settings",
+        type = "group",
+        inline = true,
+        args = {
+          showClient = {
+            order = 0,
+            name = "Restrict Open Client to Officers",
+            desc = "If enabled, the loot window will only be able to be automatically shown by officers in your guild.",
+            type = "toggle",
+            width = 2,
+            set = function(_, val) self:SetPref("ShowClientOfficers", val) end,
+            get = function() return self:GetPref("ShowClientOfficers") end,
+          }
+        }
+      },
+      devTools = {
+        order = 2,
         name = "Developer Tools",
         type = "group",
         inline = true,


### PR DESCRIPTION
Added an option for clients (non-loot masters) to not receive open client requests from non-officers.

Also added new section in the options for "Client" options since it's not a loot master specific option, maybe more client options in the future!