### PR TITLE
Using Loot via itemLink not ItemId

### DIFF
--- a/src/Item.lua
+++ b/src/Item.lua
@@ -6,6 +6,7 @@ local _G, setmetatable, table, tonumber = _G, setmetatable, table, tonumber
 -- WoW APIs
 local C_Item, BItem, GetItemInfo, ItemLocation = C_Item, Item, GetItemInfo, ItemLocation
 local GetContainerItemID = C_Container and C_Container.GetContainerItemID or GetContainerItemID
+local GetContainerItemLink = C_Container and C_Container.GetContainerItemLink or GetContainerItemLink
 local GetContainerNumSlots = C_Container and C_Container.GetContainerNumSlots or GetContainerNumSlots
 local BIND_TRADE_TIME_REMAINING, NUM_BAG_SLOTS = BIND_TRADE_TIME_REMAINING, NUM_BAG_SLOTS
 local CreateFrame, UIParent = CreateFrame, UIParent
@@ -33,14 +34,15 @@ function Item:CreateForId(itemId)
   if C_Item.IsItemDataCachedByID(itemId) then
     item:PopulateStaticProperties()
   else
-    BItem:CreateFromItemID(itemId):ContinueOnItemLoad(function() item:PopulateStaticProperties() end)
+    BItem:CreateFromItemLink(itemId):ContinueOnItemLoad(function() item:PopulateStaticProperties() end)
   end
 
   return item
 end
 
 function Item:CreateFromContainer(bag, slot)
-  local itemId = GetContainerItemID(bag, slot)
+  --local itemId = GetContainerItemID(bag, slot)
+  local itemId = GetContainerItemLink(bag, slot)
   if not itemId then return nil end
 
   local item = Item:CreateForId(itemId)
@@ -155,7 +157,7 @@ end
 function Item:Decode(encodedStr)
   local elements = NotaLoot:Split(encodedStr, NotaLoot.SEPARATOR.ELEMENT)
 
-  local item = self:CreateForId(tonumber(elements[1]))
+  local item = self:CreateForId(elements[1])
   item.info = { status = tonumber(elements[2]), winner = elements[3] }
 
   return item

--- a/src/Master.lua
+++ b/src/Master.lua
@@ -654,10 +654,10 @@ function Master:OnLootMessage(text, ...)
   local player = select(4, ... )
   if player ~= NotaLoot.player then return end
 
-  local _, itemId = text:match(LOOT_ITEM_SELF:sub(1, -4)..".*|Hitem:((%d+).-)|h")
+  local itemId = text:match(LOOT_ITEM_SELF:sub(1, -4)..".*|Hitem:([^|]+)|h%[([^%]]+)%]|h")
   if not itemId then return end
 
-  local item = NotaLoot.Item:CreateForId(tonumber(itemId))
+  local item = NotaLoot.Item:CreateForId(itemId)
   if item.quality >= 4 then -- Only auto add epic or higher quality
     table.insert(self.pendingAutoAddedItems, item)
   end

--- a/src/NotaLoot.lua
+++ b/src/NotaLoot.lua
@@ -61,7 +61,7 @@ NotaLoot.MESSAGE = {
 NotaLoot.SEPARATOR = {
   ARG = ";",
   ELEMENT = ",",
-  LIST_ELEMENT = ":",
+  LIST_ELEMENT = "^",
   MESSAGE = "&",
   SUBLIST_ELEMENT = "/",
 }

--- a/src/NotaLoot_Cata.toc
+++ b/src/NotaLoot_Cata.toc
@@ -2,7 +2,7 @@
 ## Title: Nota Loot
 ## Notes: Loot distribution helper developed for nota
 ## Author: Bluephobia
-## Version: 4.0.4
+## Version: 4.0.5
 ## SavedVariables: NotaLootPrefs
 
 embeds.xml

--- a/src/NotaLoot_Classic.toc
+++ b/src/NotaLoot_Classic.toc
@@ -2,7 +2,7 @@
 ## Title: Nota Loot
 ## Notes: Loot distribution helper developed for nota
 ## Author: Bluephobia
-## Version: 4.0.4
+## Version: 4.0.5
 ## SavedVariables: NotaLootPrefs
 
 embeds.xml

--- a/src/NotaLoot_Wrath.toc
+++ b/src/NotaLoot_Wrath.toc
@@ -2,7 +2,7 @@
 ## Title: Nota Loot
 ## Notes: Loot distribution helper developed for nota
 ## Author: Bluephobia
-## Version: 4.0.4
+## Version: 4.0.5
 ## SavedVariables: NotaLootPrefs
 
 embeds.xml


### PR DESCRIPTION
Updated Item to be created via ItemLink not ItemId.
Tested with a few individual people.

Updated caching to also work via ItemLink not ItemId.

